### PR TITLE
Add fastboot compatibility

### DIFF
--- a/blueprints/ember-uikit/index.js
+++ b/blueprints/ember-uikit/index.js
@@ -1,15 +1,15 @@
 /* eslint-env node */
 
-const path = require("path");
-const fs = require("fs");
-const chalk = require("chalk");
+const path = require('path');
+const fs = require('fs');
+const chalk = require('chalk');
 
 module.exports = {
   normalizeEntityName() {},
 
   afterInstall() {
-    let stylePath = path.join("app", "styles");
-    let file = path.join(stylePath, "app.scss");
+    let stylePath = path.join('app', 'styles');
+    let file = path.join(stylePath, 'app.scss');
     let importStatement = "@import 'ember-uikit';";
 
     if (!fs.existsSync(stylePath)) {
@@ -22,8 +22,8 @@ module.exports = {
       fs.writeFileSync(file, importStatement);
     }
 
-    this._writeStatusToUI(chalk.green, "add import statement", file);
+    this._writeStatusToUI(chalk.green, 'add import statement', file);
 
-    return this.addAddonToProject("ember-cli-sass");
+    return this.addAddonToProject('ember-cli-sass');
   }
 };

--- a/index.js
+++ b/index.js
@@ -101,6 +101,15 @@ module.exports = {
 
     this.uikitOptions = options;
 
+    if (
+      this.uikitOptions.whitelist.length &&
+      this.uikitOptions.blacklist.length
+    ) {
+      this.ui.writeWarnLine(
+        '[ember-uikit]: `blacklist` and `whitelist` should not be used simultaneously - ignoring whitelist.'
+      );
+    }
+
     if (!this.uikitOptions.useIcons) {
       this.uikitOptions.blacklist.push('uk-icon');
     }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const Funnel = require('broccoli-funnel');
 const Merge = require('broccoli-merge-trees');
+const map = require('broccoli-stew').map;
 const path = require('path');
 
 const DEFAULT_OPTIONS = {
@@ -72,6 +73,22 @@ module.exports = {
     return new Merge([uikitStyles, tree].filter(Boolean));
   },
 
+  treeForVendor(tree) {
+    let uikitScripts = new Funnel(
+      path.join(this._getNodeModulesPath(), 'uikit', 'dist', 'js'),
+      {
+        include: ['uikit.js', 'uikit-icons.js']
+      }
+    );
+
+    uikitScripts = map(
+      uikitScripts,
+      content => `if (typeof FastBoot === undefined) { ${content} }`
+    );
+
+    return new Merge([tree, uikitScripts].filter(Boolean));
+  },
+
   included() {
     this._super.included.apply(this, arguments);
 
@@ -94,10 +111,10 @@ module.exports = {
     }
 
     if (this.uikitOptions.importUIkitJS) {
-      this.app.import(path.join(this._getDistPath(), 'js', 'uikit.js'));
+      this.app.import(path.join('vendor', 'uikit.js'));
 
       if (this.uikitOptions.useIcons) {
-        this.app.import(path.join(this._getDistPath(), 'js', 'uikit-icons.js'));
+        this.app.import(path.join('vendor', 'uikit-icons.js'));
       }
     }
   },
@@ -187,10 +204,6 @@ module.exports = {
 
   _getNodeModulesPath() {
     return path.relative(process.cwd(), this.app.project.nodeModulesPath);
-  },
-
-  _getDistPath() {
-    return path.join(this._getNodeModulesPath(), 'uikit', 'dist');
   },
 
   _getIconsPath() {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "chalk": "^2.3.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,7 +1454,7 @@ broccoli-static-compiler@^0.1.4:
     broccoli-writer "^0.1.1"
     mkdirp "^0.3.5"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2472,7 +2472,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.3.1:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.7:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2485,9 +2485,9 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli@~2.16.2:
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.16.2.tgz#53b922073a8e6f34255a6e0dcb1794a91ba3e1b7"
+ember-cli@~2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.17.0.tgz#4f8b1890724e54e780242ff4d05b498e367e3461"
   dependencies:
     amd-name-resolver "1.0.0"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
@@ -2559,7 +2559,7 @@ ember-cli@~2.16.2:
     promise-map-series "^0.2.1"
     quick-temp "^0.1.8"
     resolve "^1.3.0"
-    rsvp "^3.6.0"
+    rsvp "^4.7.0"
     sane "^1.6.0"
     semver "^5.1.1"
     silent-error "^1.0.0"
@@ -2684,9 +2684,9 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-source@~2.16.0:
-  version "2.16.2"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.16.2.tgz#ebc29ce36dec3ecc80f6b1b02218d63ca5041088"
+ember-source@~2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.17.0.tgz#b78871dd49bd8d642b80176df4faf7fd7d059dac"
   dependencies:
     broccoli-funnel "^1.2.0"
     broccoli-merge-trees "^2.0.0"
@@ -2697,7 +2697,7 @@ ember-source@~2.16.0:
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-valid-component-name "^1.0.0"
-    ember-cli-version-checker "^1.3.1"
+    ember-cli-version-checker "^2.1.0"
     ember-router-generator "^1.2.3"
     fs-extra "^4.0.1"
     inflection "^1.12.0"
@@ -6336,11 +6336,11 @@ rollup@^0.41.4:
   dependencies:
     source-map-support "^0.4.0"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0, rsvp@^3.6.0:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
-rsvp@^4.6.1:
+rsvp@^4.6.1, rsvp@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.7.0.tgz#dc1b0b1a536f7dec9d2be45e0a12ad4197c9fd96"
 


### PR DESCRIPTION
This PR would implement #11 but does not yet include any tests. This is only tested locally yet. But as far as I understand, we need to release a version supporting fastboot in order to be able to test fastboot compatibility with [ember-fastboot-addon-tests](https://github.com/kaliber5/ember-fastboot-addon-tests),

Based off #13 so that needs to be merged before.