### PR TITLE
Renovate: Try "update-lockfile" strategy for dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,18 @@
 {
-  "extends": ["config:js-lib"],
+  "extends": ["config:base"],
   "packageRules": [
+    {
+      "packagePatterns": ["*"],
+      "rangeStrategy": "update-lockfile"
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "rangeStrategy": "pin"
+    },
+    {
+      "depTypeList": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
     {
       "packageNames": ["eslint-plugin-prettier"],
       "matchCurrentVersion": "2.6.0"


### PR DESCRIPTION
This way, we should still get PRs for updates about our dependencies,
without forcing downstream apps to use specific version (if we'd use
pinning)