### PR TITLE
fix(modal)!: reintroduce option for close button

### DIFF
--- a/addon/components/uk-modal.js
+++ b/addon/components/uk-modal.js
@@ -7,6 +7,7 @@ import { getOwner } from "@ember/application";
 export default Component.extend({
   layout,
 
+  btnClose: true,
   escClose: true,
   bgClose: true,
   stack: false,

--- a/addon/templates/components/uk-modal.hbs
+++ b/addon/templates/components/uk-modal.hbs
@@ -1,7 +1,7 @@
 {{#-in-element container}}
   <div id="modal-{{elementId}}">
     <div class="uk-modal-dialog ">
-      {{#if closable}}<button class="uk-modal-close-default" type="button" uk-close></button>{{/if}}
+      {{#if btnClose}}<button class="uk-modal-close-default" type="button" uk-close></button>{{/if}}
       <div class="uk-modal-body">
         {{yield}}
       </div>


### PR DESCRIPTION
BREAKING CHANGE: The option is now called `btnClose` to conform more with the other UIkit options. The option `closable` doesn't make much sense now that we have multiple close-options.