### PR TITLE
fix(modal): choose correct UIkit event

### DIFF
--- a/addon/components/uk-modal.js
+++ b/addon/components/uk-modal.js
@@ -56,7 +56,7 @@ export default Component.extend({
     );
 
     UIkit.util.on(id, "show", () => this._show());
-    UIkit.util.on(id, "hide", () => this._hide());
+    UIkit.util.on(id, "hidden", () => this._hide());
   },
 
   didReceiveAttrs() {


### PR DESCRIPTION
We have the problem that in Internet Explorer the container of the modal dialogs is not hidden on close via Escape key.

After much debugging it turns out that the change of the `visible` variable initiated by the `on-hide` action in the template interferes with the hiding process. In effect the promise that (when resolved) triggers the removal of the `display` property throws undefined and leaves the user with a transparent container over the whole page which prevents any further interaction with the page.

https://github.com/uikit/uikit/blob/develop/src/js/mixin/togglable.js#L144

Changing the UIkit event we listen to in our Ember component fixes the problem as the newly chosen event occurs after UIkit has done its deed and we cannot mess up the hiding process anymore.

`"hide"` -> `"hidden"`
https://getuikit.com/docs/modal#events