### PR TITLE
chore: remove support for ember 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+      env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,18 +6,18 @@ module.exports = async function() {
   return {
     scenarios: [
       {
-        name: "ember-lts-3.4",
-        npm: {
-          devDependencies: {
-            "ember-source": "~3.4.0"
-          }
-        }
-      },
-      {
         name: "ember-lts-3.8",
         npm: {
           devDependencies: {
             "ember-source": "~3.8.0"
+          }
+        }
+      },
+      {
+        name: "ember-lts-3.12",
+        npm: {
+          devDependencies: {
+            "ember-source": "~3.12.0"
           }
         }
       },


### PR DESCRIPTION
BREAKING CHANGE: This removes support for ember 3.4 which is not a
supported LTS version anymore. This also adds a test matrix for the
latest LTS version 3.12