### PR TITLE
fix(modal): ignore bubbling events

### DIFF
--- a/addon/components/uk-modal.js
+++ b/addon/components/uk-modal.js
@@ -50,30 +50,40 @@ export default Component.extend({
     this.set("container", config.APP.rootElement || "body");
 
     this.set("eventHandlers", {
-      hidden: async () => {
-        if (this.visible) {
-          await this.getWithDefault("on-hide", noop)();
-        }
+      hidden: async event => {
+        if (event.currentTarget === event.target) {
+          if (this.visible) {
+            await this.getWithDefault("on-hide", noop)();
+          }
 
-        this.set("isAnimating", false);
-      },
-
-      show: async () => {
-        if (!this.visible) {
-          await this.getWithDefault("on-show", noop)();
+          this.set("isAnimating", false);
         }
       },
 
-      shown: () => {
-        this.set("isAnimating", false);
+      show: async event => {
+        if (event.currentTarget === event.target) {
+          if (!this.visible) {
+            await this.getWithDefault("on-show", noop)();
+          }
+        }
       },
 
-      beforehide: () => {
-        this.set("isAnimating", true);
+      shown: event => {
+        if (event.currentTarget === event.target) {
+          this.set("isAnimating", false);
+        }
       },
 
-      beforeshow: () => {
-        this.set("isAnimating", true);
+      beforehide: event => {
+        if (event.currentTarget === event.target) {
+          this.set("isAnimating", true);
+        }
+      },
+
+      beforeshow: event => {
+        if (event.currentTarget === event.target) {
+          this.set("isAnimating", true);
+        }
       }
     });
   },

--- a/tests/integration/components/uk-modal-test.js
+++ b/tests/integration/components/uk-modal-test.js
@@ -1,6 +1,12 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render, click, waitFor } from "@ember/test-helpers";
+import {
+  render,
+  click,
+  waitFor,
+  triggerEvent,
+  settled
+} from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | uk-modal", function(hooks) {
@@ -59,5 +65,25 @@ module("Integration | Component | uk-modal", function(hooks) {
 
     assert.dom(".uk-modal.uk-open").doesNotExist();
     assert.verifySteps(["hide"]);
+  });
+
+  test("it ignores bubbling events", async function(assert) {
+    assert.expect(2);
+
+    this.set("hide", () => assert.step("hide"));
+
+    await render(hbs`
+      {{#uk-modal visible=true on-hide=this.hide as |modal|}}
+        {{#modal.body}}
+          <button data-test-target>Target</button>
+        {{/modal.body}}
+      {{/uk-modal}}
+    `);
+
+    await triggerEvent("[data-test-target]", "hidden");
+    await settled();
+
+    assert.dom(".uk-modal.uk-open").exists();
+    assert.verifySteps([]);
   });
 });


### PR DESCRIPTION
Otherwise, a "hide" event from a contained component will also close the modal.