### PR TITLE
fix modal container

### DIFF
--- a/addon/templates/components/uk-modal.hbs
+++ b/addon/templates/components/uk-modal.hbs
@@ -1,5 +1,9 @@
 {{#in-element this.containerElement insertBefore=null}}
-  <div id={{this.modalId}} class={{@modalClass}} data-test-animating={{this.isAnimating}}>
+  <div
+    id={{this.modalId}}
+    class={{@modalClass}}
+    data-test-animating={{this.isAnimating}}
+  >
     <div
       class="uk-modal-dialog {{@dialogClass}}"
       role="dialog"
@@ -7,7 +11,7 @@
       aria-labelledby={{this.modalHeaderId}}
       tabindex="-1"
       {{focus-trap
-        isActive=@visible
+        isActive=this.focusTrapActive
         shouldSelfFocus=true
         focusTrapOptions=(hash
           escapeDeactivates=true
@@ -20,11 +24,13 @@
       {{#if this.btnClose}}
         <button class="uk-modal-close-default" type="button" uk-close></button>
       {{/if}}
-      {{yield (hash
-        header = (component "uk-modal/header" id=this.modalHeaderId)
-        body = (component "uk-modal/body")
-        footer = (component "uk-modal/footer")
-      )}}
+      {{yield
+        (hash
+          header=(component "uk-modal/header" id=this.modalHeaderId)
+          body=(component "uk-modal/body")
+          footer=(component "uk-modal/footer")
+        )
+      }}
     </div>
   </div>
 {{/in-element}}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-get-config": "^0.3.0",
     "ember-in-element-polyfill": "^1.0.1",
     "ember-toggle": "^7.1.0",
-    "focus-trap": "6.2.1",
     "uikit": "^3.6.18"
   },
   "devDependencies": {
@@ -103,9 +102,6 @@
     "qunit": "2.14.1",
     "qunit-dom": "1.6.0",
     "sass": "1.32.8"
-  },
-  "resolutions": {
-    "focus-trap": "6.2.1"
   },
   "ember": {
     "edition": "octane"

--- a/tests/integration/components/uk-modal-test.js
+++ b/tests/integration/components/uk-modal-test.js
@@ -79,4 +79,19 @@ module("Integration | Component | uk-modal", function (hooks) {
 
     assert.verifySteps([]);
   });
+
+  test("it renders in container", async function (assert) {
+    assert.expect(1);
+
+    await render(hbs`
+      <div id="modal-container"></div>
+      <UkModal @visible=true @container="#modal-container" as |Modal|>
+        <Modal.body>
+          <button data-test-target>Target</button>
+        </Modal.body>
+      </UkModal>
+    `);
+
+    assert.dom("#modal-container div.uk-modal.uk-open").exists();
+  });
 });

--- a/tests/integration/components/uk-modal-test.js
+++ b/tests/integration/components/uk-modal-test.js
@@ -62,6 +62,26 @@ module("Integration | Component | uk-modal", function (hooks) {
     assert.verifySteps(["hide"]);
   });
 
+  test("it triggers the on-show action", async function (assert) {
+    assert.expect(2);
+
+    this.set("show", () => assert.step("show"));
+    this.set("visible", false);
+
+    await render(hbs`
+      {{#uk-modal visible=this.visible on-show=this.show as |modal|}}
+        {{#modal.header}}
+          <h2>Test</h2>
+        {{/modal.header}}
+      {{/uk-modal}}
+    `);
+
+    this.set("visible", true);
+    await waitFor(".uk-modal[data-test-animating]", { count: 0 });
+
+    assert.verifySteps(["show"]);
+  });
+
   test("it ignores bubbling events", async function (assert) {
     assert.expect(1);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5838,9 +5838,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.649:
-  version "1.3.695"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.695.tgz#955f419cf99137226180cc4cca2e59015a4e248d"
-  integrity sha512-lz66RliUqLHU1Ojxx1A4QUxKydjiQ79Y4dZyPobs2Dmxj5aVL2TM3KoQ2Gs7HS703Bfny+ukI3KOxwAB0xceHQ==
+  version "1.3.698"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.698.tgz#5de813960f23581a268718a0058683dffa15d221"
+  integrity sha512-VEXDzYblnlT+g8Q3gedwzgKOso1evkeJzV8lih7lV8mL8eAnGVnKyC3KsFT6S+R5PQO4ffdr1PI16/ElibY/kQ==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -7169,9 +7169,9 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     safe-buffer "^5.1.1"
 
 exec-sh@^0.3.2:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.5.tgz#1b46bd6bcbf54fdc1e926a4f3d90126d42cec3df"
-  integrity sha512-0hzpaUazv4mEccxdn3TXC+HWNeVXNKMCJRK6E7Xyg+LwGAYI3yFag6jTkd4injV+kChYDQS1ftqDhnDVWNhU8A==
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
+  integrity sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
 
 execa@^0.7.0:
   version "0.7.0"
@@ -7718,12 +7718,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@6.2.1, focus-trap@^6.2.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.2.1.tgz#20edaa4a5eb21d9c2c9859653747edbdf7a6bf0e"
-  integrity sha512-WX23tBrHkyx+ogYOGPyJFWEmpleZesEcoK4EvBgZd++hEzW6P+5H0o9suM0Cw+M9E4cKmGKngxXU7sYg5qTiRQ==
+focus-trap@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.3.0.tgz#31c08f0b6099705f71f6e0a16d88fbcc4c012586"
+  integrity sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==
   dependencies:
-    tabbable "^5.1.4"
+    tabbable "^5.1.5"
 
 follow-redirects@^1.0.0:
   version "1.13.3"
@@ -12066,10 +12066,10 @@ prettier@2.2.1, prettier@^2.2.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-printf@^0.5.1:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/printf/-/printf-0.5.3.tgz#8b7eec278d886833312238b2bf42b2b6f250880a"
-  integrity sha512-t3lYN6vPU5PZXDiEZZqoyXvN8wCsBfi8gPoxTKo2e5hhV673t/KUh+mfO8P8lCOCDC/BWcOGIxKyebxc5FuqLA==
+printf@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/printf/-/printf-0.6.1.tgz#b9afa3d3b55b7f2e8b1715272479fc756ed88650"
+  integrity sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==
 
 prismjs@^1.22.0:
   version "1.23.0"
@@ -12691,9 +12691,9 @@ regjsparser@^0.1.4:
     jsesc "~0.5.0"
 
 regjsparser@^0.6.4:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.8.tgz#4532c3da36d75d56e3f394ce2ea6842bde7496bd"
-  integrity sha512-3weFrFQREJhJ2PW+iCGaG6TenyzNSZgsBKZ/oEf6Trme31COSeIWhHw9O6FPkuXktfx+b6Hf/5e6dKPHaROq2g==
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.9.tgz#b489eef7c9a2ce43727627011429cf833a7183e6"
+  integrity sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -14004,7 +14004,7 @@ sync-disk-cache@^2.0.0:
     rimraf "^3.0.0"
     username-sync "^1.0.2"
 
-tabbable@^5.1.4:
+tabbable@^5.1.5:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.6.tgz#dd495abe81d5e41e003fbfa70952e20d5e1e1e89"
   integrity sha512-KSlGaSX9PbL7FHDTn2dB+zv61prkY8BeGioTsKfeN7dKhw5uz1S4U2iFaWMK4GR8oU+5OFBkFuxbMsaUxVVlrQ==
@@ -14120,9 +14120,9 @@ test-exclude@^6.0.0:
     minimatch "^3.0.4"
 
 testem@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-3.3.0.tgz#355f47339aa04302da05f631ec9f417d577c010c"
-  integrity sha512-PFfiqOVJKdkhMJoTd6wFH82q4GAX12pTA8uPGPAZHlgIobo6iHskv/IeJVPAhWzfRVNWmRWs1WhmnlS0/3IDtg==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-3.4.0.tgz#48ab6b98e96085eeddac1fb46337872b13e9e06c"
+  integrity sha512-09mhy7fQj9o1W1c/Lfcs56FYqhFiZrXZjnOSJn+KxWAdYjbF5yHEuGrg+L5ooBlleCGD9r1TQwKd3+DixskT0Q==
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"
@@ -14145,7 +14145,7 @@ testem@^3.2.0:
     mustache "^3.0.0"
     node-notifier "^9.0.1"
     npmlog "^4.0.0"
-    printf "^0.5.1"
+    printf "^0.6.1"
     rimraf "^2.4.4"
     socket.io "^2.1.0"
     spawn-args "^0.2.0"


### PR DESCRIPTION
The documentation states that the `container` argument can be set to a string
which will then be used as the container query string. Until now the argument
was ignored and just set to the `rootElement` or `body`.
